### PR TITLE
Fix fetchVideoURL

### DIFF
--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -331,6 +331,7 @@
         let content = await resp.text();
         let match = content.match(pattern);
         let videoUrl = JSON.parse(match[1]);
+	videoUrl = videoUrl.replace(/^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/?\n]+)/g, 'https://scontent.cdninstagram.com');
         videoElem.setAttribute('videoURL', videoUrl)
         return videoUrl;
     }


### PR DESCRIPTION
The provided url video is blocked by the browser
Blocked: NotSameOrigin
The provided PR just works for me, merge with caution.

