### PR TITLE
Add z-index to custom buttons

### DIFF
--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -169,7 +169,7 @@
 		newBtn.innerHTML = svg.replace('%color', iconColor);
 		newBtn.setAttribute('class', 'custom-btn ' + className);
 		newBtn.setAttribute('target', '_blank');
-		newBtn.setAttribute('style', 'cursor: pointer;margin-left: ' + marginLeft + ';margin-top: 8px;');
+		newBtn.setAttribute('style', 'cursor: pointer;margin-left: ' + marginLeft + ';margin-top: 8px;z-index: 999;');
 		newBtn.onclick = onClickHandler;
 		if (prefetchAndAttachLink) newBtn.onmouseenter = onMouseInHandler;
 		if (className.includes('newtab')) {


### PR DESCRIPTION
Prevents clickable surface hiding under other elements.

One example where this can happen is if a user shares a post to their story and they adjust the position of the post so that it overlaps the button.  (Yes, some people do have the post flying off the top-right corner of the screen, rather than leaving it in the center where you can see it. 😂)

Tested the fix and verified it works in said situation.  And only the anchor element needs to be adjusted, because the download icon was still visible, I just couldn't click it without triggering Instagram's popup text prompting me to view the post.