### PR TITLE
Makes shortcuts work on OS X, perhaps other OSes

### DIFF
--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -93,7 +93,7 @@
             preventDefault: function () { }
         };
 
-        if (event.altKey && event.key === 'k') {
+        if (event.altKey && event.code === 'KeyK') {
             let buttons = document.getElementsByClassName('download-btn');
             if (buttons.length > 0) {
                 let mockEvent = { ...mockEventTemplate };
@@ -102,7 +102,7 @@
                 onClickHandler(mockEvent);
             }
         }
-        if (event.altKey && event.key === 'i') {
+        if (event.altKey && event.code === 'KeyI') {
             let buttons = document.getElementsByClassName('newtab-btn');
             if (buttons.length > 0) {
                 let mockEvent = { ...mockEventTemplate };
@@ -112,7 +112,7 @@
             }
         }
 
-        if (event.altKey && event.key === 'l') {
+        if (event.altKey && event.code === 'KeyL') {
             // right arrow
             let buttons = document.getElementsByClassName('_9zm2');
             if (buttons.length > 0) {
@@ -120,7 +120,7 @@
             }
         }
 
-        if (event.altKey && event.key === 'j') {
+        if (event.altKey && event.code === 'KeyJ') {
             // left arrow
             let buttons = document.getElementsByClassName('_9zm0');
             if (buttons.length > 0) {

--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -93,7 +93,7 @@
             preventDefault: function () { }
         };
 
-        if (event.altKey && event.code === 'KeyK') {
+        if (event.altKey && (event.code === 'KeyK' || event.key == 'k')) {
             let buttons = document.getElementsByClassName('download-btn');
             if (buttons.length > 0) {
                 let mockEvent = { ...mockEventTemplate };
@@ -102,7 +102,7 @@
                 onClickHandler(mockEvent);
             }
         }
-        if (event.altKey && event.code === 'KeyI') {
+        if (event.altKey && (event.code === 'KeyI' || event.key == 'i')) {
             let buttons = document.getElementsByClassName('newtab-btn');
             if (buttons.length > 0) {
                 let mockEvent = { ...mockEventTemplate };
@@ -112,7 +112,7 @@
             }
         }
 
-        if (event.altKey && event.code === 'KeyL') {
+        if (event.altKey && (event.code === 'KeyL' || event.key == 'l')) {
             // right arrow
             let buttons = document.getElementsByClassName('_9zm2');
             if (buttons.length > 0) {
@@ -120,7 +120,7 @@
             }
         }
 
-        if (event.altKey && event.code === 'KeyJ') {
+        if (event.altKey && (event.code === 'KeyJ' || event.key == 'j')) {
             // left arrow
             let buttons = document.getElementsByClassName('_9zm0');
             if (buttons.length > 0) {


### PR DESCRIPTION
*(First, thank you to everyone who worked on this plugin! I use it daily, and find it very useful.)*

On OS X, and perhaps other platforms, holding down the Option key (the equivalent of the Alt key) and pressing a letter produces different character. For example, alt+k produces ˚. This causes `event.key` to not compare to the correct letter and thus causes the shortcuts to fail.

This PR uses the [event.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) field, supported by most modern browsers on all platforms, to unambiguously identify the pressed key separate from any modifiers. If `event.code` is for some reason not available, the code will also check `event.key` as before.