### PR TITLE
update selectors; update icon color decision; graceful npe exit

### DIFF
--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -151,9 +151,9 @@
         const profileSelector = 'header section svg circle';
         const playSvgPathSelector = 'path[d="M5.888 22.5a3.46 3.46 0 0 1-1.721-.46l-.003-.002a3.451 3.451 0 0 1-1.72-2.982V4.943a3.445 3.445 0 0 1 5.163-2.987l12.226 7.059a3.444 3.444 0 0 1-.001 5.967l-12.22 7.056a3.462 3.462 0 0 1-1.724.462Z"]';
         const pauseSvgPathSelector = 'path[d="M15 1c-3.3 0-6 1.3-6 3v40c0 1.7 2.7 3 6 3s6-1.3 6-3V4c0-1.7-2.7-3-6-3zm18 0c-3.3 0-6 1.3-6 3v40c0 1.7 2.7 3 6 3s6-1.3 6-3V4c0-1.7-2.7-3-6-3z"]';
-        // Thanks for Jenie providing color check code
-        // https://greasyfork.org/zh-TW/scripts/406535-instagram-download-button/discussions/122185
-        let iconColor = getComputedStyle(document.body).backgroundColor === 'rgb(0, 0, 0)' ? 'white' : 'black';
+        
+        let rgb = getComputedStyle(document.body).backgroundColor.match(/[.?\d]+/g);
+        let iconColor = (rgb[0] * 0.299 + rgb[1] * 0.587 + rgb[2] * 0.114) <= 150 ? 'white' : 'black'
 
         // clear all custom buttons when url changing
         if (preUrl !== curUrl) {

--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -146,7 +146,7 @@
 
     var checkExistTimer = setInterval(function () {
         const curUrl = window.location.href;
-        const savePostSelector = 'article *:not(li)>*>*>*>div:not([class])>div[role="button"]:not([style])';
+        const savePostSelector = 'article *:not(li)>*>*>*>div:not([class])>div[role="button"]:not([style]):not([tabindex="-1"])';
         const storySelector = 'section > *:not(main) header div>svg:not([aria-label=""])';
         const profileSelector = 'header section svg circle';
         const playSvgPathSelector = 'path[d="M5.888 22.5a3.46 3.46 0 0 1-1.721-.46l-.003-.002a3.451 3.451 0 0 1-1.72-2.982V4.943a3.445 3.445 0 0 1 5.163-2.987l12.226 7.059a3.444 3.444 0 0 1-.001 5.967l-12.22 7.056a3.462 3.462 0 0 1-1.724.462Z"]';

--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -460,7 +460,7 @@
                         let postUrl = `https://www.instagram.com/p/${postId}/`;
                         let resp = await fetch(postUrl);
                         let text = await resp.text();
-                        let idMatch = text.match(mediaIdPattern);
+                        let idMatch = text ? text.match(mediaIdPattern) : [];
                         let mediaId = null;
                         for (let i = 0; i < idMatch.length; ++i) {
                             if (idMatch[i]) mediaId = idMatch[i];

--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -532,6 +532,11 @@
     }
 
     function findPostName(articleNode) {
+        let imgNoCanvas = articleNode.querySelector('article section + * a[href^="/"][href$="/"]');
+        if (imgNoCanvas) {
+          return imgNoCanvas;
+        }
+        
         // videos are handled differently
         let imgAlt = articleNode.querySelector('canvas ~ * img');
         if (imgAlt) {

--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -532,6 +532,10 @@
     }
 
     function findPostName(articleNode) {
+        // this grabs the username link that is visually in the author's post comment below the media 
+        // 'article section' includes the likes section and comment box
+        // '+ * a' pulls the first element after the section that contains a link (comment box doesn't)
+        // '[href^="/"][href$="/"]' requires the href attribute to begin and end with a slash to match a username
         let imgNoCanvas = articleNode.querySelector('article section + * a[href^="/"][href$="/"]');
         if (imgNoCanvas) {
           return imgNoCanvas;


### PR DESCRIPTION
the `savePostSelector` change avoids matching on some profile pictures depending on post type

updated dark/light background-color checker for icon colors. if using a separate theme, this looks at the actual value and decides on that versus the default Instagram color

the `method3` update will continue then exit the flow if the match isn't found instead of erroring. previously threw an NPE when doing `.length`

the `findPostName` update checks the author link of the post


note: I'm unfamiliar with existing `findPostName` flow logic, so I left those. all flows I've manually tested in the feed seem to work with the button now. if this accounts for all cases, the extra logic should be removed.