### PR TITLE
Add support for /reel/ urls

### DIFF
--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -9,7 +9,7 @@
 // @name:hi             इंस्टाग्राम डाउनलोडर
 // @name:ru             Загрузчик Instagram
 // @namespace           https://github.com/y252328/Instagram_Download_Button
-// @version             1.17.17
+// @version             1.17.18
 // @compatible          chrome
 // @description         Add the download button and the open button to download or open profile picture and media in the posts, stories, and highlights in Instagram
 // @description:zh-TW   在Instagram頁面加入下載按鈕與開啟按鈕，透過這些按鈕可以下載或開啟大頭貼與貼文、限時動態、Highlight中的照片或影片
@@ -59,8 +59,8 @@
     const datetimeTemplate = '%y%%m%%d%_%H%%M%%S%';
     // ==================
 
-    const postIdPattern = /^\/p\/([^/]+)\//;
-    const postUrlPattern = /instagram\.com\/p\/[\w-]+\//;
+    const postIdPattern = /^\/(?:p|reel)\/([^/]+)\//;
+    const postUrlPattern = /instagram\.com\/(?:p|reel)\/[\w-]+\//;
 
     var svgDownloadBtn = `<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" height="24" width="24"
      viewBox="0 0 477.867 477.867" style="fill:%color;" xml:space="preserve">


### PR DESCRIPTION
I've noticed that sometimes the buttons won't show up. Then I realised that if I share a link or click the *Go to post* button on instagram, the url I'm navigated to will be `instagram.com/reel/<ID>`, not `instagram.com/p/<ID>`.

If I manually changed the URL from `/reel/` to `/p/`, I still saw the same post and the buttons were showing up properly.

This PR adds support for parsing not just the `/p` locations but `/reel` as well.


![image](https://github.com/y252328/Instagram_Download_Button/assets/2964642/53873c3b-d4e5-41d8-b4ec-c03fb3a3f500)