### PR TITLE
Remove user-agent from download request header

### DIFF
--- a/instagram-dl.user.js
+++ b/instagram-dl.user.js
@@ -755,7 +755,6 @@
         }
         fetch(url, {
             headers: new Headers({
-                'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 105.0.0.11.118 (iPhone11,8; iOS 12_3_1; en_US; en-US; scale=2.00; 828x1792; 165586599)', //window.navigator.userAgent,
                 Origin: location.origin,
             }),
             mode: 'cors',


### PR DESCRIPTION
Example of the current error:

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://scontent-sjc3-1.cdninstagram.com/v/...
(Reason: header ‘user-agent’ is not allowed according to header ‘Access-Control-Allow-Headers’ from CORS preflight response).
```

The error is fairly cut and dry, I suspect IG/Meta changed their CORS policy sometime recently, blocking requests with "user-agent". Removing "User-Agent" from the outbound fetch headers in `downloadResource()` fixes the problem.

The fix can be quickly tested by commenting out line `:758` and attempting to download media.